### PR TITLE
Walk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # spdx-filecopyrighttext: © 2021 Lee McCuller <mcculler@caltech.edu>
 # NOTICE: Contributors should add their name to copyright and document their contributions in NOTICE
 
+test_results/
 tresults/
 
 textmat*.*
@@ -139,3 +140,6 @@ ENV/
 # Rope project settings
 .ropeproject
 **/design/data/
+
+# emacs backups
+*~

--- a/src/wield/bunch/__init__.py
+++ b/src/wield/bunch/__init__.py
@@ -10,7 +10,7 @@
 
 from ._version import version, __version__, version_info
 
-from .bunch import Bunch, FrozenBunch
+from .bunch import Bunch, FrozenBunch, walk
 
 from .deep_bunch import DeepBunch
 
@@ -18,6 +18,7 @@ from .deep_bunch import DeepBunch
 __all__ = [
     "Bunch",
     "FrozenBunch",
+    "walk",
     "DeepBunch",
     "version",
     "__version__",

--- a/src/wield/bunch/bunch.py
+++ b/src/wield/bunch/bunch.py
@@ -33,6 +33,16 @@ def gen_func(mname):
     return func
 
 
+def walk(mapping):
+    # adapted from gwinc.Struct
+    for k, v in mapping.items():
+        if isinstance(v, Mapping):
+            for sk, sv in walk(v):
+                yield k + '.' + sk, sv
+        else:
+            yield k, v
+
+
 class Bunch(object):
     """
     Cookbook method for creating bunches
@@ -147,6 +157,9 @@ class Bunch(object):
 
     def copy(self):
         return self.__class__(self._mydict.copy())
+
+    def walk(self):
+        return walk(self)
 
     __contains__ = gen_func("__contains__")
     __eq__ = gen_func("__eq__")

--- a/src/wield/bunch/deep_bunch.py
+++ b/src/wield/bunch/deep_bunch.py
@@ -9,6 +9,8 @@
 """
 from collections.abc import Mapping
 
+from .bunch import walk
+
 # unique element to use as a default argument distinct from None
 _NOARG = lambda: _NOARG
 NOARG = (_NOARG,)
@@ -335,6 +337,9 @@ class DeepBunch(object):
         if mydict is None:
             return False
         return bool(mydict)
+
+    def walk(self):
+        return walk(self)
 
 
 class DeepBunchSingleAssign(DeepBunch):

--- a/src/wield/bunch/hdf_deep_bunch.py
+++ b/src/wield/bunch/hdf_deep_bunch.py
@@ -12,6 +12,8 @@ import numpy as np
 from collections.abc import Mapping
 from .interrupt_delay import DelayedKeyboardInterrupt
 
+from .bunch import walk
+
 
 # unique element to indicate a default argument
 _NOARG = lambda: _NOARG
@@ -431,6 +433,9 @@ class HDFDeepBunch(object):
         for key in list(hdf.keys()):
             yield key, self[key]
         return
+
+    def walk(self):
+        return walk(self)
 
 
 Mapping.register(HDFDeepBunch)

--- a/src/wield/bunch/test/test_walk.py
+++ b/src/wield/bunch/test/test_walk.py
@@ -1,0 +1,54 @@
+from collections.abc import Mapping
+from wield.bunch import Bunch, DeepBunch, walk
+from wield.bunch.hdf_deep_bunch import HDFDeepBunch
+from wield.pytest import tpath_join, dprint
+from wield.utilities.file_io import load, save
+
+
+def test_bunch(dprint):
+    b = Bunch()
+    b.a = 1
+    b.c = 2
+    b.b = Bunch(z=1, x=Bunch(y=12, k=23), y=dict(a=1, b=80))
+    dprint(b)
+    for k, v in b.walk():
+        dprint(k, v)
+
+
+def test_deepbunch(dprint):
+    b = DeepBunch()
+    b.a = 1
+    b.c = 2
+    b.b.z = 1
+    b.b.y = dict(a=1, b=80)
+    b.b.x.y = 12
+    b.b.x.k = 23
+    dprint(b)
+    for k, v in b.walk():
+        dprint(k, v)
+
+
+def test_hdfdeepbunch(tpath_join, dprint):
+    b = DeepBunch()
+    b.a = 1
+    b.c = 2
+    b.b.z = 1
+    b.b.y = dict(a=1, b=80)
+    b.b.x.y = 12
+    b.b.x.k = 23
+    dprint(b)
+    for k, v in b.walk():
+        dprint(k, v)
+    save(tpath_join('data.h5'), b)
+    b2 = load(tpath_join('data.h5'))
+    dprint(b2)
+    for k, v, in b2.walk():
+        dprint(k, v)
+
+
+def test_dict(dprint):
+    b = dict(a=1, c=2)
+    b['b'] = dict(z=1, x=dict(y=12, k=23), y=dict(a=1, b=80))
+    dprint(b)
+    for k, v in walk(b):
+        dprint(k, v)


### PR DESCRIPTION
Adds a `gwinc.Struct`-like walk function to iterate through all elements of a mapping. It's made a function so that it can be used as a method in `Bunch`, `DeepBunch`, and `HDFDeepBunch` and so that it can be imported and used on non-bunch mappings.

Could be refactored.