### PR TITLE
Bunch getitem always returns a Bunch

### DIFF
--- a/src/wield/bunch/bunch.py
+++ b/src/wield/bunch/bunch.py
@@ -115,9 +115,9 @@ class Bunch(object):
                     rebuild[vkey] = val
             if not rebuild:
                 raise RuntimeError("Not holding arrays to index by {0}".format(key))
-            return Bunch(rebuild)
+            return self.__class__(rebuild)
         else:
-            return self._mydict[key]
+            return self.__class__(self._mydict[key])
 
     def domain_sort(self, key):
         argsort = np.argsort(self[key])


### PR DESCRIPTION
This modifies `Bunch.__getitem__` so that a `Bunch` is always returned even if the value is a dictionary. For example, if
```python
a = Bunch(b=dict(x=1, y=2))
```
then `a.b` is a `Bunch` instead of `dict`. This is useful for looping through elements, especially in conjunction with `walk`. This change is especially useful for the construction
```python
from wield.utilities.file_io import load
data = Bunch(load(filename))
```
since, unlike with `gwinc.Struct`, `Bunch` does not recursively make `Bunch`'s for nested `dict`'s.

To make the value always be a `Bunch` with iterators, the `__iter__` method would still need to be modified however.